### PR TITLE
feat: apply rose theme and simplify cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,32 +1,74 @@
 @import "tailwindcss";
 
-@theme {
-  --color-background: 0 0% 100%;
-  --color-foreground: 222.2 84% 4.9%;
-  --color-card: 0 0% 100%;
-  --color-card-foreground: 222.2 84% 4.9%;
-  --color-popover: 0 0% 100%;
-  --color-popover-foreground: 222.2 84% 4.9%;
-  --color-primary: 350 89% 60%;
-  --color-primary-foreground: 355 100% 97%;
-  --color-secondary: 210 40% 96%;
-  --color-secondary-foreground: 222.2 84% 4.9%;
-  --color-muted: 210 40% 96%;
-  --color-muted-foreground: 215.4 16.3% 46.9%;
-  --color-accent: 210 40% 96%;
-  --color-accent-foreground: 222.2 84% 4.9%;
-  --color-destructive: 0 84.2% 60.2%;
-  --color-destructive-foreground: 210 40% 98%;
-  --color-border: 214.3 31.8% 91.4%;
-  --color-input: 214.3 31.8% 91.4%;
-  --color-ring: 350 89% 60%;
-  --radius: 0.5rem;
-  --font-inter: 'Inter', sans-serif;
-
-  /* Animations */
-  --animate-accordion-down: accordion-down 0.2s ease-out;
-  --animate-accordion-up: accordion-up 0.2s ease-out;
+:root {
+  --radius: 0.65rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.141 0.005 285.823);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.141 0.005 285.823);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.141 0.005 285.823);
+  --primary: oklch(0.645 0.246 16.439);
+  --primary-foreground: oklch(0.969 0.015 12.422);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.967 0.001 286.375);
+  --muted-foreground: oklch(0.552 0.016 285.938);
+  --accent: oklch(0.967 0.001 286.375);
+  --accent-foreground: oklch(0.21 0.006 285.885);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.92 0.004 286.32);
+  --input: oklch(0.92 0.004 286.32);
+  --ring: oklch(0.645 0.246 16.439);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.141 0.005 285.823);
+  --sidebar-primary: oklch(0.645 0.246 16.439);
+  --sidebar-primary-foreground: oklch(0.969 0.015 12.422);
+  --sidebar-accent: oklch(0.967 0.001 286.375);
+  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
+  --sidebar-border: oklch(0.92 0.004 286.32);
+  --sidebar-ring: oklch(0.645 0.246 16.439);
 }
+
+.dark {
+  --background: oklch(0.141 0.005 285.823);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.21 0.006 285.885);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.21 0.006 285.885);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.645 0.246 16.439);
+  --primary-foreground: oklch(0.969 0.015 12.422);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.274 0.006 286.033);
+  --muted-foreground: oklch(0.705 0.015 286.067);
+  --accent: oklch(0.274 0.006 286.033);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.645 0.246 16.439);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.21 0.006 285.885);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.645 0.246 16.439);
+  --sidebar-primary-foreground: oklch(0.969 0.015 12.422);
+  --sidebar-accent: oklch(0.274 0.006 286.033);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.645 0.246 16.439);
+}
+
 
 @keyframes accordion-down {
   from { height: 0; }
@@ -38,29 +80,6 @@
   to { height: 0; }
 }
 
-@media (prefers-color-scheme: dark) {
-  @theme {
-    --color-background: 222.2 84% 4.9%;
-    --color-foreground: 210 40% 98%;
-    --color-card: 222.2 84% 4.9%;
-    --color-card-foreground: 210 40% 98%;
-    --color-popover: 222.2 84% 4.9%;
-    --color-popover-foreground: 210 40% 98%;
-    --color-primary: 351 94% 71%;
-    --color-primary-foreground: 222.2 84% 4.9%;
-    --color-secondary: 217.2 32.6% 17.5%;
-    --color-secondary-foreground: 210 40% 98%;
-    --color-muted: 217.2 32.6% 17.5%;
-    --color-muted-foreground: 215 20.2% 65.1%;
-    --color-accent: 217.2 32.6% 17.5%;
-    --color-accent-foreground: 210 40% 98%;
-    --color-destructive: 0 62.8% 30.6%;
-    --color-destructive-foreground: 210 40% 98%;
-    --color-border: 217.2 32.6% 17.5%;
-    --color-input: 217.2 32.6% 17.5%;
-    --color-ring: 350 89% 60%;
-  }
-}
 
 body {
   font-family: var(--font-inter), system-ui, sans-serif;

--- a/app/globals.css
+++ b/app/globals.css
@@ -65,3 +65,29 @@
 body {
   font-family: var(--font-inter), system-ui, sans-serif;
 }
+
+@keyframes marquee-left {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@keyframes marquee-right {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(50%);
+  }
+}
+
+.animate-marquee-left {
+  animation: marquee-left 40s linear infinite;
+}
+
+.animate-marquee-right {
+  animation: marquee-right 40s linear infinite;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,8 +7,8 @@
   --color-card-foreground: 222.2 84% 4.9%;
   --color-popover: 0 0% 100%;
   --color-popover-foreground: 222.2 84% 4.9%;
-  --color-primary: 221.2 83.2% 53.3%;
-  --color-primary-foreground: 210 40% 98%;
+  --color-primary: 350 89% 60%;
+  --color-primary-foreground: 355 100% 97%;
   --color-secondary: 210 40% 96%;
   --color-secondary-foreground: 222.2 84% 4.9%;
   --color-muted: 210 40% 96%;
@@ -19,7 +19,7 @@
   --color-destructive-foreground: 210 40% 98%;
   --color-border: 214.3 31.8% 91.4%;
   --color-input: 214.3 31.8% 91.4%;
-  --color-ring: 221.2 83.2% 53.3%;
+  --color-ring: 350 89% 60%;
   --radius: 0.5rem;
   --font-inter: 'Inter', sans-serif;
 
@@ -46,7 +46,7 @@
     --color-card-foreground: 210 40% 98%;
     --color-popover: 222.2 84% 4.9%;
     --color-popover-foreground: 210 40% 98%;
-    --color-primary: 217.2 91.2% 59.8%;
+    --color-primary: 351 94% 71%;
     --color-primary-foreground: 222.2 84% 4.9%;
     --color-secondary: 217.2 32.6% 17.5%;
     --color-secondary-foreground: 210 40% 98%;
@@ -58,7 +58,7 @@
     --color-destructive-foreground: 210 40% 98%;
     --color-border: 217.2 32.6% 17.5%;
     --color-input: 217.2 32.6% 17.5%;
-    --color-ring: 224.3 76.3% 94.1%;
+    --color-ring: 350 89% 60%;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,7 @@
 @import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
 
 :root {
   --radius: 0.65rem;
@@ -17,6 +20,7 @@
   --accent: oklch(0.967 0.001 286.375);
   --accent-foreground: oklch(0.21 0.006 285.885);
   --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.969 0.015 12.422);
   --border: oklch(0.92 0.004 286.32);
   --input: oklch(0.92 0.004 286.32);
   --ring: oklch(0.645 0.246 16.439);
@@ -51,6 +55,7 @@
   --accent: oklch(0.274 0.006 286.033);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.969 0.015 12.422);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.645 0.246 16.439);
@@ -69,7 +74,6 @@
   --sidebar-ring: oklch(0.645 0.246 16.439);
 }
 
-
 @keyframes accordion-down {
   from { height: 0; }
   to { height: var(--radix-accordion-content-height); }
@@ -79,7 +83,6 @@
   from { height: var(--radix-accordion-content-height); }
   to { height: 0; }
 }
-
 
 body {
   font-family: var(--font-inter), system-ui, sans-serif;
@@ -109,4 +112,49 @@ body {
 
 .animate-marquee-right {
   animation: marquee-right 40s linear infinite;
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --border-radius: var(--radius);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
 }

--- a/components.json
+++ b/components.json
@@ -5,7 +5,7 @@
   "tsx": true,
   "tailwind": {
     "css": "app/globals.css",
-    "baseColor": "slate",
+    "baseColor": "rose",
     "cssVariables": true,
     "prefix": ""
   },

--- a/components/booking-form.tsx
+++ b/components/booking-form.tsx
@@ -113,7 +113,7 @@ const BookingForm = () => {
 
   if (isSubmitted) {
     return (
-      <section id="booking" className="py-20 bg-gradient-to-br from-blue-50 to-orange-50">
+      <section id="booking" className="py-20">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <motion.div
             initial={{ opacity: 0, scale: 0.9 }}
@@ -121,8 +121,8 @@ const BookingForm = () => {
             transition={{ duration: 0.6 }}
             className="text-center"
           >
-            <Card className="max-w-md mx-auto bg-white shadow-xl">
-              <CardContent className="p-8">
+            <Card className="max-w-md mx-auto">
+              <CardContent>
                 <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
                   <CheckCircle className="w-8 h-8 text-green-600" />
                 </div>
@@ -134,7 +134,7 @@ const BookingForm = () => {
                 </p>
                 <Button
                   onClick={() => setIsSubmitted(false)}
-                  className="w-full bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800"
+                  className="w-full"
                 >
                   继续了解课程
                 </Button>
@@ -147,7 +147,7 @@ const BookingForm = () => {
   }
 
   return (
-    <section id="booking" className="py-20 bg-gradient-to-br from-blue-50 to-orange-50">
+    <section id="booking" className="py-20">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
         <motion.div
@@ -183,7 +183,7 @@ const BookingForm = () => {
                   const IconComponent = benefit.icon;
                   return (
                     <div key={benefit.title} className="flex items-start space-x-4">
-                      <div className="w-12 h-12 bg-gradient-to-r from-blue-500 to-orange-400 rounded-lg flex items-center justify-center flex-shrink-0">
+                      <div className="w-12 h-12 bg-rose-500 rounded-lg flex items-center justify-center flex-shrink-0">
                         <IconComponent className="w-6 h-6 text-white" />
                       </div>
                       <div>
@@ -228,7 +228,7 @@ const BookingForm = () => {
             transition={{ duration: 0.6, delay: 0.4 }}
             viewport={{ once: true }}
           >
-            <Card className="bg-white shadow-xl">
+            <Card>
               <CardHeader>
                 <CardTitle className="text-2xl font-bold text-gray-900">
                   预约试听课程
@@ -357,7 +357,7 @@ const BookingForm = () => {
                   <Button
                     type="submit"
                     disabled={isSubmitting}
-                    className="w-full bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-lg py-6"
+                    className="w-full text-lg py-6"
                   >
                     {isSubmitting ? (
                       <div className="flex items-center">

--- a/components/course-schedule.tsx
+++ b/components/course-schedule.tsx
@@ -327,8 +327,13 @@ const CourseSchedule = () => {
               transition={{ duration: 0.6, delay: index * 0.1 }}
               whileHover={{ scale: 1.02 }}
             >
-              <Card className="h-full">
-                <CardHeader>
+              <Card className="h-full overflow-hidden flex flex-col">
+                <img
+                  src={`https://source.unsplash.com/seed/${activeStage}-${index}/400x200?kid`}
+                  alt={item.theme}
+                  className="w-full h-32 object-cover"
+                />
+                <CardHeader className="pb-2">
                   <div className="flex items-center justify-between">
                     <CardTitle className="text-xl font-bold text-gray-900">
                       {item.month}
@@ -340,7 +345,7 @@ const CourseSchedule = () => {
                   </CardDescription>
                 </CardHeader>
 
-                <CardContent>
+                <CardContent className="flex flex-col flex-1">
                   <div>
                     <h4 className="font-semibold text-gray-900 mb-2 flex items-center">
                       <BookOpen className="w-4 h-4 mr-2 text-gray-600" />
@@ -365,7 +370,7 @@ const CourseSchedule = () => {
                     <p className="text-sm text-gray-700">{item.homeExtension}</p>
                   </div>
 
-                  <div className="pt-4 border-t border-gray-100">
+                  <div className="pt-4 mt-auto border-t border-gray-100">
                     <div className="flex items-center justify-between text-xs text-gray-500">
                       <span>{currentStage.frequency}</span>
                       <span>小班互动</span>

--- a/components/course-schedule.tsx
+++ b/components/course-schedule.tsx
@@ -272,7 +272,7 @@ const CourseSchedule = () => {
           transition={{ duration: 0.4 }}
           className="text-center mb-12"
         >
-          <div className="bg-gradient-to-r from-blue-50 to-orange-50 rounded-2xl p-8">
+          <div className="bg-rose-50 rounded-2xl p-8">
             <h3 className="text-2xl font-bold text-gray-900 mb-2">
               {currentStage.title}
             </h3>
@@ -298,16 +298,15 @@ const CourseSchedule = () => {
           {features.map((feature, index) => {
             const IconComponent = feature.icon;
             return (
-              <div
-                key={feature.title}
-                className="text-center p-6 bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow"
-              >
-                <div className="w-12 h-12 bg-gradient-to-r from-blue-500 to-orange-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
-                  <IconComponent className="w-6 h-6 text-white" />
-                </div>
-                <h3 className="font-semibold text-gray-900 mb-2">{feature.title}</h3>
-                <p className="text-sm text-gray-600">{feature.description}</p>
-              </div>
+              <Card className="text-center" key={feature.title}>
+                <CardContent>
+                  <div className="w-12 h-12 bg-rose-500 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                    <IconComponent className="w-6 h-6 text-white" />
+                  </div>
+                  <h3 className="font-semibold text-gray-900 mb-2">{feature.title}</h3>
+                  <p className="text-sm text-gray-600">{feature.description}</p>
+                </CardContent>
+              </Card>
             );
           })}
         </motion.div>
@@ -328,8 +327,8 @@ const CourseSchedule = () => {
               transition={{ duration: 0.6, delay: index * 0.1 }}
               whileHover={{ scale: 1.02 }}
             >
-              <Card className="h-full bg-white border-l-4 border-l-blue-500 hover:shadow-lg transition-all duration-300">
-                <CardHeader className="pb-4">
+              <Card className="h-full">
+                <CardHeader>
                   <div className="flex items-center justify-between">
                     <CardTitle className="text-xl font-bold text-gray-900">
                       {item.month}
@@ -341,7 +340,7 @@ const CourseSchedule = () => {
                   </CardDescription>
                 </CardHeader>
 
-                <CardContent className="space-y-4">
+                <CardContent>
                   <div>
                     <h4 className="font-semibold text-gray-900 mb-2 flex items-center">
                       <BookOpen className="w-4 h-4 mr-2 text-gray-600" />
@@ -387,7 +386,7 @@ const CourseSchedule = () => {
           viewport={{ once: true }}
           className="mt-16 text-center"
         >
-          <div className="bg-gradient-to-r from-blue-500 to-orange-400 rounded-2xl p-8 text-white">
+          <div className="bg-rose-500 rounded-2xl p-8 text-white">
             <h3 className="text-2xl font-bold mb-4">
               完整学年，系统进阶
             </h3>

--- a/components/course-schedule.tsx
+++ b/components/course-schedule.tsx
@@ -2,9 +2,9 @@
 
 import { useState } from "react";
 import { motion } from "framer-motion";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Calendar, BookOpen, Users, Sparkles, Home } from "lucide-react";
+import { Calendar, BookOpen, Users, Sparkles } from "lucide-react";
 
 const CourseSchedule = () => {
   const [activeStage, setActiveStage] = useState<'beginner' | 'systematic' | 'advanced'>('beginner');
@@ -317,70 +317,31 @@ const CourseSchedule = () => {
           initial={{ opacity: 0, y: 30 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
-          className="grid lg:grid-cols-2 xl:grid-cols-3 gap-6"
         >
-          {currentStage.schedule.map((item, index) => (
-            <motion.div
-              key={`${activeStage}-${item.month}`}
-              initial={{ opacity: 0, y: 50 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: index * 0.1 }}
-              whileHover={{ scale: 1.02 }}
-            >
-              <Card className="h-full overflow-hidden flex flex-col">
-                <img
-                  src={`https://source.unsplash.com/seed/${activeStage}-${index}/400x200?kid`}
-                  alt={item.theme}
-                  className="w-full h-32 object-cover"
-                />
-                <CardHeader className="pb-2">
-                  <div className="flex items-center justify-between">
-                    <CardTitle className="text-xl font-bold text-gray-900">
-                      {item.month}
-                    </CardTitle>
-                    <div className="text-2xl">{item.icon}</div>
-                  </div>
-                  <CardDescription className="text-lg font-medium text-blue-600">
-                    {item.theme}
-                  </CardDescription>
-                </CardHeader>
-
-                <CardContent className="flex flex-col flex-1">
-                  <div>
-                    <h4 className="font-semibold text-gray-900 mb-2 flex items-center">
-                      <BookOpen className="w-4 h-4 mr-2 text-gray-600" />
-                      核心技能
-                    </h4>
-                    <p className="text-sm text-gray-700">{item.skills}</p>
-                  </div>
-
-                  <div>
-                    <h4 className="font-semibold text-gray-900 mb-2 flex items-center">
-                      <Sparkles className="w-4 h-4 mr-2 text-gray-600" />
-                      课堂活动
-                    </h4>
-                    <p className="text-sm text-gray-700">{item.activity}</p>
-                  </div>
-
-                  <div>
-                    <h4 className="font-semibold text-gray-900 mb-2 flex items-center">
-                      <Home className="w-4 h-4 mr-2 text-gray-600" />
-                      家庭延伸
-                    </h4>
-                    <p className="text-sm text-gray-700">{item.homeExtension}</p>
-                  </div>
-
-                  <div className="pt-4 mt-auto border-t border-gray-100">
-                    <div className="flex items-center justify-between text-xs text-gray-500">
-                      <span>{currentStage.frequency}</span>
-                      <span>小班互动</span>
-                      <span>成果展示</span>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </motion.div>
-          ))}
+          <ol className="relative border-l ml-4 pl-8">
+            {currentStage.schedule.map((item, index) => (
+              <motion.li
+                key={`${activeStage}-${item.month}`}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.4, delay: index * 0.1 }}
+                className="mb-10 ml-6"
+              >
+                <span className="absolute -left-4 flex items-center justify-center w-8 h-8 bg-rose-500 rounded-full text-white">
+                  {item.icon}
+                </span>
+                <time className="mb-1 text-sm font-medium leading-none text-gray-900">
+                  {item.month}
+                </time>
+                <h3 className="text-lg font-semibold text-rose-600 mb-2">
+                  {item.theme}
+                </h3>
+                <p className="text-sm text-gray-700 mb-1">核心技能：{item.skills}</p>
+                <p className="text-sm text-gray-700 mb-1">课堂活动：{item.activity}</p>
+                <p className="text-sm text-gray-700">家庭延伸：{item.homeExtension}</p>
+              </motion.li>
+            ))}
+          </ol>
         </motion.div>
 
         {/* Bottom Info */}

--- a/components/course-system.tsx
+++ b/components/course-system.tsx
@@ -111,8 +111,8 @@ const CourseSystem = () => {
                 whileHover={{ scale: 1.02 }}
                 className="h-full"
               >
-                <Card className="h-full bg-card hover:shadow-md transition-all duration-300">
-                  <CardHeader className="pb-4">
+                <Card>
+                  <CardHeader>
                     <div className="flex items-center justify-between mb-4">
                       <div className="w-12 h-12 rounded-lg bg-rose-500 flex items-center justify-center">
                         <IconComponent className="w-6 h-6 text-white" />
@@ -130,7 +130,7 @@ const CourseSystem = () => {
                     </CardDescription>
                   </CardHeader>
 
-                  <CardContent className="space-y-6">
+                  <CardContent>
                     {/* Goals */}
                     <div>
                       <div className="flex items-center mb-3">
@@ -189,10 +189,7 @@ const CourseSystem = () => {
                     </div>
 
                     {/* CTA Button */}
-                    <Button 
-                      onClick={scrollToBooking}
-                      className="w-full bg-rose-600 hover:bg-rose-700"
-                    >
+                    <Button onClick={scrollToBooking} className="w-full">
                       立即预约试听
                     </Button>
                   </CardContent>
@@ -217,11 +214,7 @@ const CourseSystem = () => {
             <p className="text-lg text-muted-foreground mb-6">
               我们提供免费英语水平测试，为您的孩子量身定制学习方案
             </p>
-            <Button 
-              size="lg"
-              onClick={scrollToBooking}
-              className="bg-rose-600 hover:bg-rose-700"
-            >
+            <Button size="lg" onClick={scrollToBooking}>
               预约免费测试
             </Button>
           </div>

--- a/components/faq-section.tsx
+++ b/components/faq-section.tsx
@@ -8,6 +8,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
 import { MessageCircle, Phone, Clock } from "lucide-react";
 
 const FAQSection = () => {
@@ -134,24 +135,23 @@ const FAQSection = () => {
           {contactOptions.map((option, index) => {
             const IconComponent = option.icon;
             return (
-              <div
-                key={option.title}
-                className="text-center p-6 bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow"
-              >
-                <div className="w-12 h-12 bg-gradient-to-r from-blue-500 to-orange-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
-                  <IconComponent className="w-6 h-6 text-white" />
-                </div>
-                <h3 className="font-semibold text-gray-900 mb-2">{option.title}</h3>
-                <p className="text-sm text-gray-600 mb-4">{option.description}</p>
-                <Button
-                  onClick={scrollToBooking}
-                  variant="outline"
-                  size="sm"
-                  className="border-blue-600 text-blue-600 hover:bg-blue-50"
-                >
-                  {option.action}
-                </Button>
-              </div>
+              <Card key={option.title} className="text-center">
+                <CardContent>
+                  <div className="w-12 h-12 bg-rose-500 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                    <IconComponent className="w-6 h-6 text-white" />
+                  </div>
+                  <h3 className="font-semibold text-gray-900 mb-2">{option.title}</h3>
+                  <p className="text-sm text-gray-600 mb-4">{option.description}</p>
+                  <Button
+                    onClick={scrollToBooking}
+                    variant="outline"
+                    size="sm"
+                    className="border-rose-600 text-rose-600 hover:bg-rose-50"
+                  >
+                    {option.action}
+                  </Button>
+                </CardContent>
+              </Card>
             );
           })}
         </motion.div>
@@ -164,7 +164,7 @@ const FAQSection = () => {
           viewport={{ once: true }}
           className="text-center"
         >
-          <div className="bg-gradient-to-r from-blue-600 to-orange-500 rounded-2xl p-8 text-white">
+          <div className="bg-rose-500 rounded-2xl p-8 text-white">
             <h3 className="text-2xl font-bold mb-4">
               还有其他问题？
             </h3>
@@ -176,7 +176,7 @@ const FAQSection = () => {
             <Button
               onClick={scrollToBooking}
               size="lg"
-              className="bg-white text-blue-600 hover:bg-gray-100 font-semibold"
+              className="bg-white text-rose-600 hover:bg-gray-100 font-semibold"
             >
               立即咨询
             </Button>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -62,7 +62,7 @@ const Footer = () => {
             className="lg:col-span-1"
           >
             <div className="flex items-center space-x-2 mb-6">
-              <div className="w-10 h-10 bg-gradient-to-br from-blue-500 to-orange-400 rounded-lg flex items-center justify-center">
+              <div className="w-10 h-10 bg-rose-500 rounded-lg flex items-center justify-center">
                 <span className="text-white font-bold">T</span>
               </div>
               <div>
@@ -153,7 +153,7 @@ const Footer = () => {
             <Button
               onClick={() => scrollToSection("booking")}
               size="lg"
-              className="bg-gradient-to-r from-blue-600 to-orange-500 hover:from-blue-700 hover:to-orange-600 px-8 py-3 text-lg"
+              className="px-8 py-3 text-lg"
             >
               立即预约试听
             </Button>

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -36,9 +36,9 @@ const HeroSection = () => {
               transition={{ duration: 0.8, delay: 0.2 }}
               className="text-4xl sm:text-5xl lg:text-6xl font-bold text-gray-900 leading-tight"
             >
-              <span className="text-rose-600">双语未来</span>
+              <span className="text-rose-600">自信说英语</span>
               <br />
-              从小开始！
+              让世界触手可及
             </motion.h1>
 
             <motion.p
@@ -48,10 +48,10 @@ const HeroSection = () => {
               className="text-xl sm:text-2xl text-gray-600 mt-6 font-medium"
             >
               <span className="text-blue-600">启蒙（3–6岁）</span> |{" "}
-              <span className="text-green-600">系统（6–10岁）</span> |{" "}
+              <span className="text-green-600">进阶（6–10岁）</span> |{" "}
               <span className="text-orange-600">强化（10岁+）</span>
               <br />
-              三阶段全覆盖
+              三阶段科学规划
             </motion.p>
 
             <motion.p
@@ -60,7 +60,7 @@ const HeroSection = () => {
               transition={{ duration: 0.8, delay: 0.6 }}
               className="text-lg text-gray-600 mt-4"
             >
-              小班制互动教学 · 情景化课堂 · 家校结合 · 成果可见
+              沉浸式小班 · 外教领读 · 家校共育 · 成果看得见
             </motion.p>
 
             <motion.div

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -12,7 +12,7 @@ const HeroSection = () => {
   };
 
   return (
-    <section className="relative min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-orange-50 overflow-hidden">
+    <section className="relative min-h-screen flex items-center justify-center bg-rose-50 overflow-hidden">
       {/* Background Pattern */}
       <div className="absolute inset-0 opacity-5">
         <div className="absolute top-20 left-20 w-32 h-32 bg-blue-500 rounded-full"></div>
@@ -36,9 +36,7 @@ const HeroSection = () => {
               transition={{ duration: 0.8, delay: 0.2 }}
               className="text-4xl sm:text-5xl lg:text-6xl font-bold text-gray-900 leading-tight"
             >
-              <span className="bg-gradient-to-r from-blue-600 to-orange-500 bg-clip-text text-transparent">
-                双语未来
-              </span>
+              <span className="text-rose-600">双语未来</span>
               <br />
               从小开始！
             </motion.h1>
@@ -74,7 +72,7 @@ const HeroSection = () => {
               <Button
                 size="lg"
                 onClick={() => scrollToSection("booking")}
-                className="text-lg px-8 py-6 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105"
+                className="text-lg px-8 py-6 shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105"
               >
                 立即预约试听
               </Button>
@@ -82,7 +80,7 @@ const HeroSection = () => {
                 size="lg"
                 variant="outline"
                 onClick={() => scrollToSection("courses")}
-                className="text-lg px-8 py-6 border-2 border-blue-600 text-blue-600 hover:bg-blue-50 transition-all duration-300"
+                className="text-lg px-8 py-6 border-2 border-rose-600 text-rose-600 hover:bg-rose-50 transition-all duration-300"
               >
                 了解课程体系
               </Button>
@@ -119,9 +117,9 @@ const HeroSection = () => {
           >
             <div className="relative bg-white rounded-2xl shadow-2xl p-8 transform rotate-2 hover:rotate-0 transition-transform duration-500">
               {/* Placeholder for hero image */}
-              <div className="aspect-[4/3] bg-gradient-to-br from-blue-100 to-orange-100 rounded-xl flex items-center justify-center">
+              <div className="aspect-[4/3] bg-rose-100 rounded-xl flex items-center justify-center">
                 <div className="text-center">
-                  <div className="w-24 h-24 bg-gradient-to-br from-blue-500 to-orange-400 rounded-full mx-auto mb-4 flex items-center justify-center">
+                  <div className="w-24 h-24 bg-rose-500 rounded-full mx-auto mb-4 flex items-center justify-center">
                     <span className="text-white text-2xl font-bold">🎓</span>
                   </div>
                   <p className="text-gray-600 font-medium">

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -46,7 +46,7 @@ const Navigation = () => {
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
           <div className="flex items-center space-x-2">
-            <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-orange-400 rounded-lg flex items-center justify-center">
+            <div className="w-8 h-8 bg-rose-500 rounded-lg flex items-center justify-center">
               <span className="text-white font-bold text-sm">T</span>
             </div>
             <span className="text-xl font-bold text-gray-900">
@@ -69,9 +69,8 @@ const Navigation = () => {
 
           {/* CTA Button */}
           <div className="hidden md:block">
-            <Button 
+            <Button
               onClick={() => scrollToSection("booking")}
-              className="bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800"
             >
               立即预约
             </Button>
@@ -102,9 +101,9 @@ const Navigation = () => {
                 </button>
               ))}
               <div className="px-3 py-2">
-                <Button 
+                <Button
                   onClick={() => scrollToSection("booking")}
-                  className="w-full bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800"
+                  className="w-full"
                 >
                   立即预约
                 </Button>

--- a/components/pricing-section.tsx
+++ b/components/pricing-section.tsx
@@ -108,16 +108,16 @@ const PricingSection = () => {
           {offers.map((offer, index) => {
             const IconComponent = offer.icon;
             return (
-              <motion.div
-                key={offer.title}
-                whileHover={{ y: -4 }}
-                className="text-center p-5 bg-card rounded-lg shadow-sm hover:shadow-md transition-all duration-300 border"
-              >
-                <div className="w-12 h-12 bg-rose-500 rounded-lg mx-auto mb-3 flex items-center justify-center">
-                  <IconComponent className="w-6 h-6 text-white" />
-                </div>
-                <h3 className="text-base font-bold text-foreground mb-2">{offer.title}</h3>
-                <p className="text-xs text-muted-foreground">{offer.description}</p>
+              <motion.div key={offer.title} whileHover={{ y: -4 }}>
+                <Card className="text-center">
+                  <CardContent>
+                    <div className="w-12 h-12 bg-rose-500 rounded-lg mx-auto mb-3 flex items-center justify-center">
+                      <IconComponent className="w-6 h-6 text-white" />
+                    </div>
+                    <h3 className="text-base font-bold text-foreground mb-2">{offer.title}</h3>
+                    <p className="text-xs text-muted-foreground">{offer.description}</p>
+                  </CardContent>
+                </Card>
               </motion.div>
             );
           })}
@@ -143,8 +143,8 @@ const PricingSection = () => {
                 </div>
               )}
               
-              <Card className={`h-full ${plan.popular ? 'border-rose-500 border-2 shadow-md' : ''} hover:shadow-md transition-all duration-300`}>
-                <CardHeader className="text-center pb-4">
+              <Card className="h-full">
+                <CardHeader>
                   <CardTitle className="text-xl font-bold text-foreground mb-2">
                     {plan.stage}
                   </CardTitle>
@@ -157,7 +157,7 @@ const PricingSection = () => {
                   </CardDescription>
                 </CardHeader>
 
-                <CardContent className="space-y-4">
+                <CardContent>
                   <ul className="space-y-3">
                     {plan.features.map((feature, i) => (
                       <li key={i} className="flex items-center text-sm text-foreground">
@@ -169,11 +169,7 @@ const PricingSection = () => {
 
                   <Button
                     onClick={scrollToBooking}
-                    className={`w-full mt-6 ${
-                      plan.popular
-                        ? 'bg-rose-600 hover:bg-rose-700'
-                        : 'bg-foreground hover:bg-foreground/90'
-                    }`}
+                    className="w-full mt-6"
                   >
                     立即预约试听
                   </Button>
@@ -217,22 +213,20 @@ const PricingSection = () => {
             </div>
             
             <div className="text-center">
-              <div className="bg-card rounded-xl p-6 shadow-sm border">
-                <div className="text-3xl mb-4">📞</div>
-                <h4 className="text-lg font-bold text-foreground mb-2">
-                  专业课程顾问咨询
-                </h4>
-                <p className="text-muted-foreground mb-4">
-                  获取详细价格方案和个性化学习建议
-                </p>
-                <Button
-                  onClick={scrollToBooking}
-                  variant="outline"
-                  className="border-rose-600 text-rose-600 hover:bg-rose-50"
-                >
-                  立即咨询
-                </Button>
-              </div>
+              <Card>
+                <CardContent className="text-center">
+                  <div className="text-3xl mb-4">📞</div>
+                  <h4 className="text-lg font-bold text-foreground mb-2">
+                    专业课程顾问咨询
+                  </h4>
+                  <p className="text-muted-foreground mb-4">
+                    获取详细价格方案和个性化学习建议
+                  </p>
+                  <Button onClick={scrollToBooking} variant="outline">
+                    立即咨询
+                  </Button>
+                </CardContent>
+              </Card>
             </div>
           </div>
         </motion.div>

--- a/components/teacher-team.tsx
+++ b/components/teacher-team.tsx
@@ -1,8 +1,14 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Award, BookOpen, Heart, Star } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Award, BookOpen, Heart, Star, Check } from "lucide-react";
 
 const TeacherTeam = () => {
   const teachers = [
@@ -10,42 +16,44 @@ const TeacherTeam = () => {
       name: "Emily Chen",
       title: "启蒙期主教",
       experience: "8年教学经验",
-      certifications: ["TESOL认证", "儿童心理学"],
-      specialty: "幼儿英语启蒙、TPR教学法",
-      philosophy: "让每个孩子在快乐中爱上英语",
-      avatar: "👩‍🏫",
-      highlights: ["专业幼教背景", "双语家庭育儿经验", "获年度优秀教师"]
+      image: "https://randomuser.me/api/portraits/women/12.jpg",
+      highlights: ["TESOL认证", "儿童心理学背景", "TPR教学专家"],
     },
     {
-      name: "David Wilson",
+      name: "Olivia Brown",
       title: "系统期主教",
       experience: "6年教学经验",
-      certifications: ["TEFL认证", "剑桥英语证书"],
-      specialty: "语法教学、阅读写作",
-      philosophy: "用系统化方法构建英语思维",
-      avatar: "👨‍🎓",
-      highlights: ["英语专业硕士", "英国留学背景", "学生考试通过率98%"]
+      image: "https://randomuser.me/api/portraits/women/45.jpg",
+      highlights: ["英语教育硕士", "剑桥英语认证", "阅读写作指导"],
     },
     {
-      name: "Sarah Johnson",
+      name: "Sophia Johnson",
       title: "强化期主教",
       experience: "10年教学经验",
-      certifications: ["TESOL高级", "雅思官方培训师"],
-      specialty: "考试备考、演讲辩论",
-      philosophy: "培养学生的批判性思维和表达能力",
-      avatar: "👩‍💼",
-      highlights: ["国际学校任教经验", "雅思托福专家", "学术写作指导"]
+      image: "https://randomuser.me/api/portraits/women/33.jpg",
+      highlights: ["雅思官方培训师", "演讲辩论教练", "学术写作专家"],
     },
     {
-      name: "Michael Zhang",
+      name: "Mia Davis",
+      title: "课程顾问",
+      experience: "7年教学经验",
+      image: "https://randomuser.me/api/portraits/women/76.jpg",
+      highlights: ["教育技术认证", "课程体系设计", "家校沟通达人"],
+    },
+    {
+      name: "Emma Garcia",
+      title: "教研主管",
+      experience: "9年教学经验",
+      image: "https://randomuser.me/api/portraits/women/19.jpg",
+      highlights: ["双语教研背景", "课堂活动设计", "教师培训导师"],
+    },
+    {
+      name: "Ava Thompson",
       title: "助教主管",
       experience: "5年教学经验",
-      certifications: ["TKT证书", "教育技术认证"],
-      specialty: "课程设计、家校沟通",
-      philosophy: "科技赋能教育，让学习更高效",
-      avatar: "👨‍💻",
-      highlights: ["教育技术专家", "课程体系设计", "家长满意度95%"]
-    }
+      image: "https://randomuser.me/api/portraits/women/52.jpg",
+      highlights: ["教育心理学", "课堂管理", "家长满意度95%"],
+    },
   ];
 
   const teamStats = [
@@ -112,25 +120,30 @@ const TeacherTeam = () => {
               transition={{ duration: 0.3, delay: index * 0.05 }}
               viewport={{ once: true }}
             >
-              <Card>
-                <CardContent className="text-center">
-                  {/* Avatar */}
-                  <div className="w-16 h-16 bg-muted rounded-full flex items-center justify-center mx-auto mb-3">
-                    <span className="text-lg font-medium text-muted-foreground">
-                      {teacher.name.split(' ').map(n => n[0]).join('')}
-                    </span>
-                  </div>
-
-                  {/* Name and Title */}
-                  <h3 className="font-semibold text-sm mb-1">
-                    {teacher.name}
-                  </h3>
-                  <p className="text-xs text-muted-foreground mb-2">
+              <Card className="overflow-hidden h-full flex flex-col">
+                <CardHeader className="items-center text-center">
+                  <img
+                    src={teacher.image}
+                    alt={teacher.name}
+                    className="w-24 h-24 rounded-full object-cover mb-3"
+                  />
+                  <CardTitle className="text-sm">{teacher.name}</CardTitle>
+                  <CardDescription className="text-xs">
                     {teacher.title}
-                  </p>
+                  </CardDescription>
                   <p className="text-xs text-muted-foreground">
                     {teacher.experience}
                   </p>
+                </CardHeader>
+                <CardContent className="pt-0">
+                  <ul className="text-xs text-muted-foreground space-y-1 text-left">
+                    {teacher.highlights.map((item) => (
+                      <li key={item} className="flex items-start">
+                        <Check className="w-3 h-3 text-rose-500 mr-2 mt-0.5" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
                 </CardContent>
               </Card>
             </motion.div>

--- a/components/teacher-team.tsx
+++ b/components/teacher-team.tsx
@@ -87,16 +87,16 @@ const TeacherTeam = () => {
           {teamStats.map((stat, index) => {
             const IconComponent = stat.icon;
             return (
-              <motion.div
-                key={stat.label}
-                whileHover={{ y: -4 }}
-                className="text-center p-4 bg-card rounded-lg shadow-sm hover:shadow-md transition-all duration-300 border"
-              >
-                <div className="w-10 h-10 bg-rose-500 rounded-lg mx-auto mb-3 flex items-center justify-center">
-                  <IconComponent className="w-5 h-5 text-white" />
-                </div>
-                <div className="text-2xl font-bold text-foreground mb-1">{stat.number}</div>
-                <div className="text-xs text-muted-foreground">{stat.label}</div>
+              <motion.div key={stat.label} whileHover={{ y: -4 }}>
+                <Card className="text-center">
+                  <CardContent>
+                    <div className="w-10 h-10 bg-rose-500 rounded-lg mx-auto mb-3 flex items-center justify-center">
+                      <IconComponent className="w-5 h-5 text-white" />
+                    </div>
+                    <div className="text-2xl font-bold text-foreground mb-1">{stat.number}</div>
+                    <div className="text-xs text-muted-foreground">{stat.label}</div>
+                  </CardContent>
+                </Card>
               </motion.div>
             );
           })}
@@ -113,7 +113,7 @@ const TeacherTeam = () => {
               viewport={{ once: true }}
             >
               <Card>
-                <CardContent className="p-4 text-center">
+                <CardContent className="text-center">
                   {/* Avatar */}
                   <div className="w-16 h-16 bg-muted rounded-full flex items-center justify-center mx-auto mb-3">
                     <span className="text-lg font-medium text-muted-foreground">
@@ -154,21 +154,27 @@ const TeacherTeam = () => {
               用爱心、耐心和专业知识，点亮孩子的英语学习之路。
             </p>
             <div className="grid sm:grid-cols-3 gap-6 max-w-4xl mx-auto">
-              <div className="bg-card rounded-lg p-4 border shadow-sm">
-                <div className="text-3xl mb-2">🎯</div>
-                <h4 className="font-semibold mb-2 text-foreground">个性化教学</h4>
-                <p className="text-sm text-muted-foreground">根据每个孩子的特点制定学习方案</p>
-              </div>
-              <div className="bg-card rounded-lg p-4 border shadow-sm">
-                <div className="text-3xl mb-2">💡</div>
-                <h4 className="font-semibold mb-2 text-foreground">启发式学习</h4>
-                <p className="text-sm text-muted-foreground">培养孩子的思考能力和创造力</p>
-              </div>
-              <div className="bg-card rounded-lg p-4 border shadow-sm">
-                <div className="text-3xl mb-2">🤝</div>
-                <h4 className="font-semibold mb-2 text-foreground">家校共育</h4>
-                <p className="text-sm text-muted-foreground">与家长密切配合，共同促进成长</p>
-              </div>
+              <Card>
+                <CardContent className="text-center">
+                  <div className="text-3xl mb-2">🎯</div>
+                  <h4 className="font-semibold mb-2 text-foreground">个性化教学</h4>
+                  <p className="text-sm text-muted-foreground">根据每个孩子的特点制定学习方案</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="text-center">
+                  <div className="text-3xl mb-2">💡</div>
+                  <h4 className="font-semibold mb-2 text-foreground">启发式学习</h4>
+                  <p className="text-sm text-muted-foreground">培养孩子的思考能力和创造力</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="text-center">
+                  <div className="text-3xl mb-2">🤝</div>
+                  <h4 className="font-semibold mb-2 text-foreground">家校共育</h4>
+                  <p className="text-sm text-muted-foreground">与家长密切配合，共同促进成长</p>
+                </CardContent>
+              </Card>
             </div>
           </div>
         </motion.div>

--- a/components/teacher-team.tsx
+++ b/components/teacher-team.tsx
@@ -125,7 +125,7 @@ const TeacherTeam = () => {
                   <img
                     src={teacher.image}
                     alt={teacher.name}
-                    className="w-24 h-24 rounded-full object-cover mb-3"
+                    className="w-24 h-24 rounded-full object-cover mb-3 mx-auto"
                   />
                   <CardTitle className="text-sm">{teacher.name}</CardTitle>
                   <CardDescription className="text-xs">

--- a/components/testimonials.tsx
+++ b/components/testimonials.tsx
@@ -105,13 +105,13 @@ const Testimonials = () => {
           className="grid grid-cols-4 gap-4 mb-16"
         >
           {stats.map((stat, index) => (
-            <motion.div
-              key={stat.label}
-              whileHover={{ y: -4 }}
-              className="text-center p-4 bg-card rounded-lg shadow-sm hover:shadow-md transition-all duration-300 border"
-            >
-              <div className="text-2xl font-bold text-foreground mb-1">{stat.number}</div>
-              <div className="text-xs text-muted-foreground">{stat.label}</div>
+            <motion.div key={stat.label} whileHover={{ y: -4 }}>
+              <Card className="text-center">
+                <CardContent>
+                  <div className="text-2xl font-bold text-foreground mb-1">{stat.number}</div>
+                  <div className="text-xs text-muted-foreground">{stat.label}</div>
+                </CardContent>
+              </Card>
             </motion.div>
           ))}
         </motion.div>
@@ -127,8 +127,8 @@ const Testimonials = () => {
               viewport={{ once: true }}
               whileHover={{ y: -4 }}
             >
-              <Card className="h-full bg-card shadow-sm hover:shadow-md transition-all duration-300 overflow-hidden">
-                <CardContent className="p-5">
+              <Card className="h-full overflow-hidden">
+                <CardContent>
                   {/* Rating */}
                   <div className="flex items-center mb-3">
                     {[...Array(testimonial.rating)].map((_, i) => (
@@ -189,22 +189,30 @@ const Testimonials = () => {
             </p>
             
             <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6 max-w-4xl mx-auto">
-              <div className="bg-card rounded-lg p-4 border shadow-sm">
-                <div className="text-2xl font-bold mb-1 text-foreground">85%</div>
-                <div className="text-sm text-muted-foreground">KET/PET通过率</div>
-              </div>
-              <div className="bg-card rounded-lg p-4 border shadow-sm">
-                <div className="text-2xl font-bold mb-1 text-foreground">50+</div>
-                <div className="text-sm text-muted-foreground">英语竞赛获奖</div>
-              </div>
-              <div className="bg-card rounded-lg p-4 border shadow-sm">
-                <div className="text-2xl font-bold mb-1 text-foreground">90%</div>
-                <div className="text-sm text-muted-foreground">升入理想学校</div>
-              </div>
-              <div className="bg-card rounded-lg p-4 border shadow-sm">
-                <div className="text-2xl font-bold mb-1 text-foreground">3年</div>
-                <div className="text-sm text-muted-foreground">平均学习周期</div>
-              </div>
+              <Card>
+                <CardContent className="text-center">
+                  <div className="text-2xl font-bold mb-1 text-foreground">85%</div>
+                  <div className="text-sm text-muted-foreground">KET/PET通过率</div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="text-center">
+                  <div className="text-2xl font-bold mb-1 text-foreground">50+</div>
+                  <div className="text-sm text-muted-foreground">英语竞赛获奖</div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="text-center">
+                  <div className="text-2xl font-bold mb-1 text-foreground">90%</div>
+                  <div className="text-sm text-muted-foreground">升入理想学校</div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="text-center">
+                  <div className="text-2xl font-bold mb-1 text-foreground">3年</div>
+                  <div className="text-sm text-muted-foreground">平均学习周期</div>
+                </CardContent>
+              </Card>
             </div>
           </div>
         </motion.div>

--- a/components/testimonials.tsx
+++ b/components/testimonials.tsx
@@ -2,10 +2,10 @@
 
 import { motion } from "framer-motion";
 import { Card, CardContent } from "@/components/ui/card";
-import { Star, Quote } from "lucide-react";
+import { Star } from "lucide-react";
 
 const Testimonials = () => {
-  const testimonials = [
+  const baseTestimonials = [
     {
       content: "Emma在TinyTalkers学了一年，从一开始的害羞不敢说，到现在能自信地用英语表达想法。老师们很有耐心，教学方法也很有趣，孩子每次上课都很开心！",
       parentName: "王妈妈",
@@ -68,6 +68,55 @@ const Testimonials = () => {
     }
   ];
 
+  const testimonials = Array.from(
+    { length: 20 },
+    (_, i) => baseTestimonials[i % baseTestimonials.length]
+  );
+  const topRow = testimonials.slice(0, 10);
+  const bottomRow = testimonials.slice(10);
+
+  const TestimonialItem = ({
+    testimonial,
+  }: {
+    testimonial: (typeof baseTestimonials)[number];
+  }) => (
+    <Card className="w-64 shrink-0">
+      <CardContent>
+        <div className="flex items-center mb-3">
+          {[...Array(testimonial.rating)].map((_, i) => (
+            <Star key={i} className="w-3 h-3 text-yellow-500 fill-current" />
+          ))}
+        </div>
+        <p className="text-foreground text-sm leading-relaxed mb-4 line-clamp-4">
+          "{testimonial.content}"
+        </p>
+        <div className="flex items-center justify-between pt-3 border-t">
+          <div className="flex items-center">
+            <div className="w-8 h-8 bg-rose-100 rounded-full flex items-center justify-center text-sm mr-2">
+              {testimonial.avatar}
+            </div>
+            <div>
+              <div className="text-sm font-medium text-foreground">
+                {testimonial.parentName}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {testimonial.childName} · {testimonial.childAge}
+              </div>
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="text-xs font-medium text-rose-600">
+              {testimonial.stage}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {testimonial.highlight}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+
   const stats = [
     { number: "1000+", label: "在读学员" },
     { number: "98%", label: "家长满意度" },
@@ -116,61 +165,25 @@ const Testimonials = () => {
           ))}
         </motion.div>
 
-        {/* Testimonials Grid */}
-        <div className="grid xl:grid-cols-3 lg:grid-cols-2 grid-cols-1 gap-6">
-          {testimonials.map((testimonial, index) => (
-            <motion.div
-              key={index}
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: index * 0.1 }}
-              viewport={{ once: true }}
-              whileHover={{ y: -4 }}
-            >
-              <Card className="h-full overflow-hidden">
-                <CardContent>
-                  {/* Rating */}
-                  <div className="flex items-center mb-3">
-                    {[...Array(testimonial.rating)].map((_, i) => (
-                      <Star key={i} className="w-3 h-3 text-yellow-500 fill-current" />
-                    ))}
-                  </div>
-
-                  {/* Content */}
-                  <p className="text-foreground text-sm leading-relaxed mb-4 line-clamp-4">
-                    "{testimonial.content}"
-                  </p>
-
-                  {/* Parent and Child Info */}
-                  <div className="flex items-center justify-between pt-3 border-t">
-                    <div className="flex items-center">
-                      <div className="w-8 h-8 bg-rose-100 rounded-full flex items-center justify-center text-sm mr-2">
-                        {testimonial.avatar}
-                      </div>
-                      <div>
-                        <div className="text-sm font-medium text-foreground">
-                          {testimonial.parentName}
-                        </div>
-                        <div className="text-xs text-muted-foreground">
-                          {testimonial.childName} · {testimonial.childAge}
-                        </div>
-                      </div>
-                    </div>
-                    
-                    <div className="text-right">
-                      <div className="text-xs font-medium text-rose-600">
-                        {testimonial.stage}
-                      </div>
-                      <div className="text-xs text-muted-foreground">
-                        {testimonial.highlight}
-                      </div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </motion.div>
-          ))}
-        </div>
+        {/* Testimonials Marquee */}
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.4 }}
+          viewport={{ once: true }}
+          className="space-y-6 overflow-hidden mb-16"
+        >
+          <div className="flex gap-6 animate-marquee-left">
+            {[...topRow, ...topRow].map((testimonial, index) => (
+              <TestimonialItem testimonial={testimonial} key={index} />
+            ))}
+          </div>
+          <div className="flex gap-6 animate-marquee-right">
+            {[...bottomRow, ...bottomRow].map((testimonial, index) => (
+              <TestimonialItem testimonial={testimonial} key={index} />
+            ))}
+          </div>
+        </motion.div>
 
         {/* Success Stories */}
         <motion.div

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "recharts": "^2.15.4",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
+        "tw-animate-css": "^1.3.6",
         "vaul": "^1.1.2",
         "zod": "^4.0.17"
       },
@@ -5356,6 +5357,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmmirror.com/tw-animate-css/-/tw-animate-css-1.3.6.tgz",
+      "integrity": "sha512-9dy0R9UsYEGmgf26L8UcHiLmSFTHa9+D7+dAt/G/sF5dCnPePZbfgDYinc7/UzAM7g/baVrmS6m9yEpU46d+LA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "recharts": "^2.15.4",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
+    "tw-animate-css": "^1.3.6",
     "vaul": "^1.1.2",
     "zod": "^4.0.17"
   },


### PR DESCRIPTION
## Summary
- switch to global shadcn rose theme
- remove custom card styles and gradients for cleaner UI

## Testing
- `npm run lint` *(fails: prompts for interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d4f1d71e883258d28cd912156fb8b